### PR TITLE
counter track support

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,6 +1,6 @@
 use perfetto_recorder::ThreadTraceData;
 use perfetto_recorder::TraceBuilder;
-use perfetto_recorder::{CounterUnit, record_counter_f64, record_counter_i64, scope};
+use perfetto_recorder::{CounterUnit, scope};
 use std::time::Instant;
 
 const N: u32 = 100_000;
@@ -44,9 +44,9 @@ fn main() -> anyhow::Result<()> {
     perfetto_recorder::current_thread_reserve(N_COUNTERS as usize * 2); // 2 events per counter
 
     let mut builder = TraceBuilder::new()?;
-    let counter_i64 =
+    let mut counter_i64 =
         builder.create_counter_track("test_counter_i64", CounterUnit::Count, 1, false);
-    let counter_f64 = builder.create_counter_track(
+    let mut counter_f64 = builder.create_counter_track(
         "test_counter_f64",
         CounterUnit::Custom("%".to_string()),
         1,
@@ -57,7 +57,7 @@ fn main() -> anyhow::Result<()> {
     let start = Instant::now();
 
     for i in 0..N_COUNTERS {
-        record_counter_i64(counter_i64, perfetto_recorder::time(), i as i64);
+        counter_i64.record_i64(perfetto_recorder::time(), i as i64);
     }
 
     let elapsed = start.elapsed();
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
     let start = Instant::now();
 
     for i in 0..N_COUNTERS {
-        record_counter_f64(counter_f64, perfetto_recorder::time(), i as f64);
+        counter_f64.record_f64(perfetto_recorder::time(), i as f64);
     }
 
     let elapsed = start.elapsed();

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,9 +1,10 @@
 use perfetto_recorder::ThreadTraceData;
 use perfetto_recorder::TraceBuilder;
-use perfetto_recorder::scope;
+use perfetto_recorder::{CounterUnit, record_counter_f64, record_counter_i64, scope};
 use std::time::Instant;
 
 const N: u32 = 100_000;
+const N_COUNTERS: u32 = 100_000;
 
 fn main() -> anyhow::Result<()> {
     perfetto_recorder::start()?;
@@ -37,6 +38,63 @@ fn main() -> anyhow::Result<()> {
         elapsed.as_millis(),
         encoded.len() as f64 / 1024_f64 / 1024_f64,
         (elapsed / N).as_nanos()
+    );
+
+    // Benchmark counter recording
+    perfetto_recorder::current_thread_reserve(N_COUNTERS as usize * 2); // 2 events per counter
+
+    let mut builder = TraceBuilder::new()?;
+    let counter_i64 =
+        builder.create_counter_track("test_counter_i64", CounterUnit::Count, 1, false);
+    let counter_f64 = builder.create_counter_track(
+        "test_counter_f64",
+        CounterUnit::Custom("%".to_string()),
+        1,
+        false,
+    );
+
+    // Measure record_counter_i64 time
+    let start = Instant::now();
+
+    for i in 0..N_COUNTERS {
+        record_counter_i64(counter_i64, perfetto_recorder::time(), i as i64);
+    }
+
+    let elapsed = start.elapsed();
+
+    println!(
+        "Average record_counter_i64 overhead: {} ns",
+        (elapsed / N_COUNTERS).as_nanos()
+    );
+
+    // Measure record_counter_f64 time
+    let start = Instant::now();
+
+    for i in 0..N_COUNTERS {
+        record_counter_f64(counter_f64, perfetto_recorder::time(), i as f64);
+    }
+
+    let elapsed = start.elapsed();
+
+    println!(
+        "Average record_counter_f64 overhead: {} ns",
+        (elapsed / N_COUNTERS).as_nanos()
+    );
+
+    // Measure encoding time for counters
+    let start = Instant::now();
+
+    let encoded = builder
+        .process_thread_data(&ThreadTraceData::take_current_thread())
+        .encode_to_vec();
+
+    let elapsed = start.elapsed();
+
+    println!(
+        "Counter encode time: {} ms for {:0.1} MiB or {} ns per counter event",
+        elapsed.as_millis(),
+        encoded.len() as f64 / 1024_f64 / 1024_f64,
+        (elapsed / N_COUNTERS).as_nanos()
     );
 
     Ok(())

--- a/examples/counters.rs
+++ b/examples/counters.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
-use perfetto_recorder::{
-    CounterUnit, ThreadTraceData, TraceBuilder, record_counter_f64, record_counter_i64,
-};
+use perfetto_recorder::{CounterUnit, ThreadTraceData, TraceBuilder};
 use std::thread;
 use std::time::Duration;
 
@@ -17,21 +15,21 @@ fn main() -> Result<()> {
     let mut trace = TraceBuilder::new()?;
 
     // Create counter tracks for system metrics
-    let cpu_counter = trace.create_counter_track(
+    let mut cpu_counter = trace.create_counter_track(
         "CPU Usage",
         CounterUnit::Custom("%".to_string()),
         1,     // Unit multiplier
         false, // Not incremental (absolute values)
     );
 
-    let memory_counter = trace.create_counter_track(
+    let mut memory_counter = trace.create_counter_track(
         "Memory Usage",
         CounterUnit::SizeBytes,
         1024 * 1024, // Convert to MB
         false,       // Not incremental
     );
 
-    let fps_counter = trace.create_counter_track(
+    let mut fps_counter = trace.create_counter_track(
         "Frame Rate",
         CounterUnit::Custom("fps".to_string()),
         1,
@@ -55,16 +53,16 @@ fn main() -> Result<()> {
         let fps = 45.0 + 15.0 * (i as f64 * 0.15).cos();
 
         // Record counter values
-        record_counter_f64(cpu_counter, timestamp, cpu_usage);
-        record_counter_i64(memory_counter, timestamp, memory_mb);
-        record_counter_f64(fps_counter, timestamp, fps);
+        cpu_counter.record_f64(timestamp, cpu_usage);
+        memory_counter.record_i64(timestamp, memory_mb);
+        fps_counter.record_f64(timestamp, fps);
 
         // Add some spikes at interesting points
         if i == 30 {
-            record_counter_f64(cpu_counter, timestamp, 95.0); // CPU spike
+            cpu_counter.record_f64(timestamp, 95.0); // CPU spike
         }
         if i == 60 {
-            record_counter_i64(memory_counter, timestamp, 1800); // Memory spike
+            memory_counter.record_i64(timestamp, 1800); // Memory spike
         }
 
         // Small delay between samples (10ms)

--- a/examples/counters.rs
+++ b/examples/counters.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use perfetto_recorder::{CounterUnit, TraceBuilder};
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<()> {
+    // Enable tracing
+    perfetto_recorder::start()?;
+
+    let trace_file = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "counters.pftrace".to_string());
+
+    // Create a trace builder
+    let mut trace = TraceBuilder::new()?;
+
+    // Create counter tracks for system metrics
+    let cpu_counter = trace.create_counter_track(
+        "CPU Usage",
+        CounterUnit::Custom("%".to_string()),
+        1,     // Unit multiplier
+        false, // Not incremental (absolute values)
+    );
+
+    let memory_counter = trace.create_counter_track(
+        "Memory Usage",
+        CounterUnit::SizeBytes,
+        1024 * 1024, // Convert to MB
+        false,       // Not incremental
+    );
+
+    let fps_counter = trace.create_counter_track(
+        "Frame Rate",
+        CounterUnit::Custom("fps".to_string()),
+        1,
+        false,
+    );
+
+    println!("Recording counter values...");
+
+    // Simulate collecting metrics over time with actual delays
+    for i in 0..100 {
+        // Get current timestamp, handle both std::time::Instant and fastant::Instant
+        let timestamp = perfetto_recorder::time();
+
+        // Simulate varying CPU usage (15-85%)
+        let cpu_usage = 50.0 + 30.0 * (i as f64 * 0.1).sin() + 5.0 * (i as f64 * 0.05).cos();
+
+        // Simulate memory usage growing over time (500-1500 MB)
+        let memory_mb = 500 + (i * 10) + ((i as f64 * 0.2).sin() * 50.0) as i64;
+
+        // Simulate frame rate varying (30-60 fps)
+        let fps = 45.0 + 15.0 * (i as f64 * 0.15).cos();
+
+        // Record counter values
+        trace.record_counter_f64(cpu_counter, timestamp, cpu_usage);
+        trace.record_counter_i64(memory_counter, timestamp, memory_mb);
+        trace.record_counter_f64(fps_counter, timestamp, fps);
+
+        // Add some spikes at interesting points
+        if i == 30 {
+            trace.record_counter_f64(cpu_counter, timestamp, 95.0); // CPU spike
+        }
+        if i == 60 {
+            trace.record_counter_i64(memory_counter, timestamp, 1800); // Memory spike
+        }
+
+        // Small delay between samples (10ms)
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    // Write the trace to a file
+    trace.write_to_file(&trace_file)?;
+    Ok(())
+}

--- a/proto/perfetto.protos.rs
+++ b/proto/perfetto.protos.rs
@@ -81,6 +81,8 @@ pub struct TrackEvent {
     pub name_field: ::core::option::Option<track_event::NameField>,
     #[prost(oneof = "track_event::SourceLocationField", tags = "33, 34")]
     pub source_location_field: ::core::option::Option<track_event::SourceLocationField>,
+    #[prost(oneof = "track_event::CounterValueField", tags = "30, 44")]
+    pub counter_value_field: ::core::option::Option<track_event::CounterValueField>,
 }
 /// Nested message and enum types in `TrackEvent`.
 pub mod track_event {
@@ -99,6 +101,7 @@ pub mod track_event {
     pub enum Type {
         SliceBegin = 1,
         SliceEnd = 2,
+        Counter = 4,
     }
     impl Type {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -109,6 +112,7 @@ pub mod track_event {
             match self {
                 Self::SliceBegin => "TYPE_SLICE_BEGIN",
                 Self::SliceEnd => "TYPE_SLICE_END",
+                Self::Counter => "TYPE_COUNTER",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -116,6 +120,7 @@ pub mod track_event {
             match value {
                 "TYPE_SLICE_BEGIN" => Some(Self::SliceBegin),
                 "TYPE_SLICE_END" => Some(Self::SliceEnd),
+                "TYPE_COUNTER" => Some(Self::Counter),
                 _ => None,
             }
         }
@@ -134,6 +139,13 @@ pub mod track_event {
         #[prost(uint64, tag = "34")]
         SourceLocationIid(u64),
     }
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
+    pub enum CounterValueField {
+        #[prost(int64, tag = "30")]
+        CounterValue(i64),
+        #[prost(double, tag = "44")]
+        DoubleCounterValue(f64),
+    }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TrackDescriptor {
@@ -145,6 +157,8 @@ pub struct TrackDescriptor {
     pub process: ::core::option::Option<ProcessDescriptor>,
     #[prost(message, optional, tag = "4")]
     pub thread: ::core::option::Option<ThreadDescriptor>,
+    #[prost(message, optional, tag = "8")]
+    pub counter: ::core::option::Option<CounterDescriptor>,
     #[prost(oneof = "track_descriptor::StaticOrDynamicName", tags = "2")]
     pub static_or_dynamic_name: ::core::option::Option<
         track_descriptor::StaticOrDynamicName,
@@ -175,6 +189,62 @@ pub struct ThreadDescriptor {
     pub tid: ::core::option::Option<i32>,
     #[prost(string, optional, tag = "5")]
     pub thread_name: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CounterDescriptor {
+    #[prost(enumeration = "counter_descriptor::Unit", optional, tag = "1")]
+    pub unit: ::core::option::Option<i32>,
+    #[prost(string, optional, tag = "2")]
+    pub unit_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int64, optional, tag = "3")]
+    pub unit_multiplier: ::core::option::Option<i64>,
+    #[prost(bool, optional, tag = "4")]
+    pub is_incremental: ::core::option::Option<bool>,
+}
+/// Nested message and enum types in `CounterDescriptor`.
+pub mod counter_descriptor {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Unit {
+        Unspecified = 0,
+        TimeNs = 1,
+        Count = 2,
+        SizeBytes = 3,
+    }
+    impl Unit {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "UNIT_UNSPECIFIED",
+                Self::TimeNs => "UNIT_TIME_NS",
+                Self::Count => "UNIT_COUNT",
+                Self::SizeBytes => "UNIT_SIZE_BYTES",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNIT_UNSPECIFIED" => Some(Self::Unspecified),
+                "UNIT_TIME_NS" => Some(Self::TimeNs),
+                "UNIT_COUNT" => Some(Self::Count),
+                "UNIT_SIZE_BYTES" => Some(Self::SizeBytes),
+                _ => None,
+            }
+        }
+    }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SourceLocation {

--- a/proto/perfetto_trace.proto
+++ b/proto/perfetto_trace.proto
@@ -42,6 +42,7 @@ message TrackEvent {
   enum Type {
     TYPE_SLICE_BEGIN = 1;
     TYPE_SLICE_END = 2;
+    TYPE_COUNTER = 4;
   }
   optional Type type = 9;
 
@@ -52,6 +53,11 @@ message TrackEvent {
   oneof source_location_field {
     SourceLocation source_location = 33;
     uint64 source_location_iid = 34;
+  }
+
+  oneof counter_value_field {
+    int64 counter_value = 30;
+    double double_counter_value = 44;
   }
 }
 
@@ -64,6 +70,7 @@ message TrackDescriptor {
 
   optional ProcessDescriptor process = 3;
   optional ThreadDescriptor thread = 4;
+  optional CounterDescriptor counter = 8;
 }
 
 message ProcessDescriptor {
@@ -76,6 +83,19 @@ message ThreadDescriptor {
   optional int32 pid = 1;
   optional int32 tid = 2;
   optional string thread_name = 5;
+}
+
+message CounterDescriptor {
+  enum Unit {
+    UNIT_UNSPECIFIED = 0;
+    UNIT_TIME_NS = 1;
+    UNIT_COUNT = 2;
+    UNIT_SIZE_BYTES = 3;
+  }
+  optional Unit unit = 1;
+  optional string unit_name = 2;
+  optional int64 unit_multiplier = 3;
+  optional bool is_incremental = 4;
 }
 
 message SourceLocation {


### PR DESCRIPTION
This PR adds support for the "Counter" track feature, as discussed in #1. The latest 4th commit reworks the API to be more idiomatic Rust. No more changes todo, reviewed the code, and it seems good.
```
// old (removed) C style API
counter_record_f64(counter, time, value)

// idiomatic Rust struct with function style
counter.record_f64(time, value)
```
The benchmark values show that counters are cheaper than spans, and encoding is approx the same cost (slightly cheaper). Performance data from a jittery laptop CPU:
```
Average span overhead: 102 ns
Encode time: 47 ms for 7.6 MiB or 474 ns per span
Average record_counter_i64 overhead: 43 ns
Average record_counter_f64 overhead: 54 ns
Counter encode time: 38 ms for 8.2 MiB or 387 ns per counter event
```
